### PR TITLE
Config enhancements #02

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -4,6 +4,7 @@ pub const DOCTOR: &str = "doctor";
 pub const EDIT: &str = "edit";
 pub const INIT: &str = "init";
 pub const LIST: &str = "list";
+pub const PATH: &str = "path";
 pub const POSTGRES_CLI: &str = "psql";
 pub const SHOW: &str = "show";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,12 +237,13 @@ fn config_init_cmd<P: AsRef<Path>>(path: P, force: bool, from: Option<(P, P)>) -
         return Ok(());
     }
 
-    // If a path is supplied, copy from the path (which must be listed in `config list -A`)
+    // If a path is supplied, copy an existing configuration file to create a
+    // new configuration.
     // - `config_file_base_path` is base location of configuration files
     // - `app_config_path` the path, as it appears in `config list -A`, e.g.
     //   "figure-cli/provenance.toml"
+    // - `path` is the destination path of the configuration file to be written
     if let Some((app_config_path, config_file_base_path)) = from {
-
         let target_config_file: Option<(PathBuf, PathBuf)> = collect_files(&config_file_base_path, Some("toml"))?
             .into_iter()
             .flat_map(|p| p.strip_prefix(config_file_base_path.as_ref()).map(|p_prefix| (p.clone(), p_prefix.to_path_buf())))

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,29 @@
 use std::net::UdpSocket;
+use std::path::{Path, PathBuf};
+use std::env::temp_dir;
+
+use getch::Getch;
+use uuid::Uuid;
 
 pub fn find_available_port() -> Result<u16, std::io::Error> {
     Ok(UdpSocket::bind("127.0.0.1:0")?.local_addr()?.port())
+}
+
+pub fn temp_file(extension: &str) -> PathBuf {
+    let mut dir = temp_dir();
+    let file_name = format!("{}.{}", Uuid::new_v4(), extension);
+
+    dir.push(file_name);
+
+    dir
+}
+
+pub fn prompt_on_write<P: AsRef<Path>>(path: P) -> bool {
+    if path.as_ref().exists() {
+        println!("\n{} already exists.\n\nOverwrite [y/n]?", path.as_ref().display());
+        let ch = Getch::new().getch().unwrap_or(0) as char;
+        ch == 'y' || ch == 'Y'
+    } else {
+        true
+    }
 }


### PR DESCRIPTION
* Make `-c`/`--config` global so it can appear in any order in the argument list
* Add a `--from` option to `config init` subcommand for copying an existing setup configuration