### PR TITLE
Kubernetes cluster port forwarding w/  remote host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,7 @@ dependencies = [
  "getch",
  "prettytable-rs",
  "quick-error",
+ "rand",
  "serde",
  "toml",
  "uuid",
@@ -259,6 +260,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
 name = "prettytable-rs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +301,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.2",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ dirs = "3.0"
 getch = "0.2.1"
 prettytable-rs = "0.8"
 quick-error = "2.0"
+rand = "0.8.4"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
 uuid = { version = "0.8", features = ["v4"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,8 @@ pub struct Config {
     // exec_test: Option<ExecConfig>,
     // exec_prod: Option<ExecConfig>,
 
+    pub port_forward: Option<PortForwardConfig>,
+
     pub postgres_local: Option<PostgresConfig>,
     pub postgres_test: Option<PostgresConfig>,
     pub postgres_prod: Option<PostgresConfig>,
@@ -51,6 +53,18 @@ impl PostgresConfig {
     pub fn schema(&self) -> String {
         self.schema.clone().unwrap_or("public".to_owned())
     }
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum PortForwardConfigType {
+    Kubernetes { context: String, namespace: String }
+}
+
+#[derive(Deserialize, Debug)]
+pub struct PortForwardConfig {
+    #[serde(rename = "type")]
+    pub _type: PortForwardConfigType,
 }
 
 // #[derive(Deserialize, Debug)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,15 +56,9 @@ impl PostgresConfig {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(rename_all = "lowercase")]
-pub enum PortForwardConfigType {
-    Kubernetes { context: String, namespace: String }
-}
-
-#[derive(Deserialize, Debug)]
 pub struct PortForwardConfig {
-    #[serde(rename = "type")]
-    pub _type: PortForwardConfigType,
+    pub context: String,
+    pub namespace: Option<String>
 }
 
 // #[derive(Deserialize, Debug)]

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -4,6 +4,7 @@ pub const DOCTOR: &str = "doctor";
 pub const EDIT: &str = "edit";
 pub const INIT: &str = "init";
 pub const LIST: &str = "list";
+pub const PATH: &str = "path";
 pub const POSTGRES_CLI: &str = "psql";
 pub const SHOW: &str = "show";
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -5,6 +5,7 @@ pub const EDIT: &str = "edit";
 pub const INIT: &str = "init";
 pub const LIST: &str = "list";
 pub const PATH: &str = "path";
+pub const PORT_FORWARD: &str = "port-forward";
 pub const POSTGRES_CLI: &str = "psql";
 pub const SHOW: &str = "show";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use std::os::unix::fs::OpenOptionsExt;
 
 use consts::*;
 use config::{EnvironmentType, environment_type, get_config};
-use crate::config::{Config, PostgresConfig, PostgresConfigType, PortForwardConfig, PortForwardConfigType};
+use crate::config::{Config, PostgresConfig, PostgresConfigType, PortForwardConfig};
 use crate::util::ForwardingInfo;
 use prettytable::{Table, format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR};
 use crate::runner::run_command;
@@ -67,13 +67,9 @@ fn collect_files<P: AsRef<Path>>(path: P, match_suffix: Option<&str>)  -> Result
 }
 
 fn k8s_port_forward(config: Option<&PortForwardConfig>, forwarding: &ForwardingInfo, context: Option<&str>, namespace: Option<&str>) -> Result<()> {
-    let (config_context, config_namespace) = if let Some(config) = config {
-        match config._type {
-            PortForwardConfigType::Kubernetes { ref context, ref namespace } =>
-                (Some(context.as_str()), Some(namespace.as_str())),
-        }
-    } else {
-        (None, None)
+    let (config_context, config_namespace) = match config {
+        Some(config) => (Some(config.context.as_str()), config.namespace.as_deref()),
+        None => (None, None)
     };
 
     // override the values from the config if `context` and `namespace` are explicitly provided:

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,12 +237,13 @@ fn config_init_cmd<P: AsRef<Path>>(path: P, force: bool, from: Option<(P, P)>) -
         return Ok(());
     }
 
-    // If a path is supplied, copy from the path (which must be listed in `config list -A`)
+    // If a path is supplied, copy an existing configuration file to create a
+    // new configuration.
     // - `config_file_base_path` is base location of configuration files
     // - `app_config_path` the path, as it appears in `config list -A`, e.g.
     //   "figure-cli/provenance.toml"
+    // - `path` is the destination path of the configuration file to be written
     if let Some((app_config_path, config_file_base_path)) = from {
-
         let target_config_file: Option<(PathBuf, PathBuf)> = collect_files(&config_file_base_path, Some("toml"))?
             .into_iter()
             .flat_map(|p| p.strip_prefix(config_file_base_path.as_ref()).map(|p_prefix| (p.clone(), p_prefix.to_path_buf())))

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,29 @@
 use std::net::UdpSocket;
+use std::path::{Path, PathBuf};
+use std::env::temp_dir;
+
+use getch::Getch;
+use uuid::Uuid;
 
 pub fn find_available_port() -> Result<u16, std::io::Error> {
     Ok(UdpSocket::bind("127.0.0.1:0")?.local_addr()?.port())
+}
+
+pub fn temp_file(extension: &str) -> PathBuf {
+    let mut dir = temp_dir();
+    let file_name = format!("{}.{}", Uuid::new_v4(), extension);
+
+    dir.push(file_name);
+
+    dir
+}
+
+pub fn prompt_on_write<P: AsRef<Path>>(path: P) -> bool {
+    if path.as_ref().exists() {
+        println!("\n{} already exists.\n\nOverwrite [y/n]?", path.as_ref().display());
+        let ch = Getch::new().getch().unwrap_or(0) as char;
+        ch == 'y' || ch == 'Y'
+    } else {
+        true
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,21 +1,71 @@
 use std::net::UdpSocket;
+use std::io;
+use std::iter;
 use std::path::{Path, PathBuf};
 use std::env::temp_dir;
 
+use rand::{Rng, thread_rng};
+use rand::distributions::Alphanumeric;
 use getch::Getch;
 use uuid::Uuid;
+
+#[derive(Clone, Debug)]
+pub struct ForwardingInfo {
+    pub local_port: u16,
+    pub remote_host: String,
+    pub remote_port: u16
+}
 
 pub fn find_available_port() -> Result<u16, std::io::Error> {
     Ok(UdpSocket::bind("127.0.0.1:0")?.local_addr()?.port())
 }
 
+/// Parses a string of the "<local-port>:<remote-host>:<remote-port>" or
+/// "<remote-host>:<remote-port>"
+pub fn parse_forwarding_string(host: &str) -> Result<ForwardingInfo, io::Error> {
+    let parts = host.split(":").collect::<Vec<&str>>();
+    if parts.len() == 3 {
+        let local_port = parts[0].parse::<u16>()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        let remote_host = parts[1];
+        let remote_port = parts[2].parse::<u16>()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        Ok(ForwardingInfo {
+            local_port,
+            remote_host: remote_host.to_owned(),
+            remote_port
+        })
+    } else if parts.len() == 2 {
+        let remote_host = parts[0];
+        let remote_port = parts[1].parse::<u16>()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        Ok(ForwardingInfo {
+            local_port: find_available_port()?, // pick a random port
+            remote_host: remote_host.to_owned(),
+            remote_port
+        })
+    } else {
+        Err(io::Error::new(io::ErrorKind::InvalidInput, "expected \
+                           \"<local-port>:<remote-host>:<remote-port>\" \
+                           or \"<remote-host>:<remote-port>\""))
+    }
+}
+
 pub fn temp_file(extension: &str) -> PathBuf {
     let mut dir = temp_dir();
     let file_name = format!("{}.{}", Uuid::new_v4(), extension);
-
     dir.push(file_name);
-
     dir
+}
+
+/// From https://docs.rs/rand/0.8.4/rand/distributions/struct.Alphanumeric.html
+pub fn random_alphanum(len: usize) -> String {
+    let mut rng = thread_rng();
+    iter::repeat(())
+        .map(|()| rng.sample(Alphanumeric))
+        .map(char::from)
+        .take(len)
+        .collect()
 }
 
 pub fn prompt_on_write<P: AsRef<Path>>(path: P) -> bool {

--- a/src/util.rs
+++ b/src/util.rs
@@ -65,7 +65,8 @@ pub fn random_alphanum(len: usize) -> String {
         .map(|()| rng.sample(Alphanumeric))
         .map(char::from)
         .take(len)
-        .collect()
+        .collect::<String>()
+        .to_lowercase()
 }
 
 pub fn prompt_on_write<P: AsRef<Path>>(path: P) -> bool {

--- a/template/config.toml.example
+++ b/template/config.toml.example
@@ -20,3 +20,4 @@ user = "<insert user name>"
 password = "<insert password>"
 database = "service-identity-db"
 schema = "service_identity"
+

--- a/template/kubectl-port-forward-remote-host.sh.template
+++ b/template/kubectl-port-forward-remote-host.sh.template
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+function cleanup {{
+  echo "Cleaning up {temp_pod_name}"
+  kubectl {context_arg} {namespace_arg} delete pod/{temp_pod_name} --grace-period 1 --wait=false
+}}
+
+trap cleanup EXIT
+
+kubectl run {context_arg} {namespace_arg} --restart=Never --image=alpine/socat {temp_pod_name} -- -d -d tcp-listen:{remote_port},fork,reuseaddr tcp-connect:{remote_host}:{remote_port}
+kubectl wait {context_arg} {namespace_arg} --for=condition=Ready pod/{temp_pod_name}
+kubectl port-forward {context_arg} {namespace_arg} pod/{temp_pod_name} {local_port}:{remote_port}
+
+echo "{temp_pod_name}"

--- a/template/kubectl-port-forward-remote-host.sh.template
+++ b/template/kubectl-port-forward-remote-host.sh.template
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Adapted from https://github.com/kubernetes/kubernetes/issues/72597#issuecomment-693149447
+
 set -e
 
 function cleanup {{
@@ -12,5 +14,3 @@ trap cleanup EXIT
 kubectl run {context_arg} {namespace_arg} --restart=Never --image=alpine/socat {temp_pod_name} -- -d -d tcp-listen:{remote_port},fork,reuseaddr tcp-connect:{remote_host}:{remote_port}
 kubectl wait {context_arg} {namespace_arg} --for=condition=Ready pod/{temp_pod_name}
 kubectl port-forward {context_arg} {namespace_arg} pod/{temp_pod_name} {local_port}:{remote_port}
-
-echo "{temp_pod_name}"

--- a/template/pgbouncer.toml.template
+++ b/template/pgbouncer.toml.template
@@ -1,0 +1,15 @@
+################## fig-cli pgbouncer configuration ##################
+
+[databases]
+{database} = host=localhost port={upstream_port} user={user} dbname={database} password={password}
+
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = {listen_port}
+unix_socket_dir =
+auth_type = any
+pool_mode = transaction
+default_pool_size = 1
+ignore_startup_parameters = extra_float_digits
+
+################## end file ##################


### PR DESCRIPTION
* Adds a new subcommand `port-forward`, which functions similarly to kubectl's `port-forward` command except that it allows for the specification of a remote host, much one would do when tunnelling with`ssh -L`.

Note: This PR contains work in https://github.com/scirner22/figure-cli/pull/2, which should be being merged first.