### PR TITLE
Patch 20220209

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
+use crate::FigError::EnvError;
 use serde::Deserialize;
 use std::fs;
 use std::path::Path;
-use crate::FigError::EnvError;
 
 #[derive(Deserialize, Debug)]
 pub struct Config {
@@ -13,7 +13,6 @@ pub struct Config {
 
     // exec_test: Option<ExecConfig>,
     // exec_prod: Option<ExecConfig>,
-
     pub port_forward: Option<PortForwardConfig>,
 
     pub postgres_local: Option<PostgresConfig>,
@@ -24,8 +23,14 @@ pub struct Config {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum PostgresConfigType {
-    Kubernetes { context: String, namespace: String, deployment: String },
-    GCloudProxy { instance: String },
+    Kubernetes {
+        context: String,
+        namespace: String,
+        deployment: String,
+    },
+    GCloudProxy {
+        instance: String,
+    },
     Direct,
 }
 
@@ -36,7 +41,7 @@ pub struct PostgresConfig {
     pub host: Option<String>,
     pub port: Option<u16>,
     pub user: String,
-    pub password: String,
+    pub password: Option<String>,
     pub database: String,
     pub schema: Option<String>,
 }
@@ -58,7 +63,7 @@ impl PostgresConfig {
 #[derive(Deserialize, Debug)]
 pub struct PortForwardConfig {
     pub context: String,
-    pub namespace: Option<String>
+    pub namespace: Option<String>,
 }
 
 // #[derive(Deserialize, Debug)]
@@ -91,13 +96,12 @@ pub fn environment_type(env: Option<&str>) -> crate::Result<EnvironmentType> {
         Some(crate::LOCAL) => Ok(EnvironmentType::Local),
         Some(crate::TEST) => Ok(EnvironmentType::Test),
         Some(crate::PRODUCTION) => Ok(EnvironmentType::Production),
-        _ => Err(EnvError("environment not set".to_owned()))
+        _ => Err(EnvError("environment not set".to_owned())),
     }
 }
 
 pub fn get_config<P: AsRef<Path>>(path: P) -> crate::Result<Config> {
     let toml_string = fs::read_to_string(path)?;
 
-    toml::from_str(&toml_string)
-        .map_err(From::from)
+    toml::from_str(&toml_string).map_err(From::from)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,14 +5,6 @@ use std::path::Path;
 
 #[derive(Deserialize, Debug)]
 pub struct Config {
-    // k8s_test: Option<K8sConfig>,
-    // k8s_prod: Option<K8sConfig>,
-
-    // log_test: Option<LogConfig>,
-    // log_prod: Option<LogConfig>,
-
-    // exec_test: Option<ExecConfig>,
-    // exec_prod: Option<ExecConfig>,
     pub port_forward: Option<PortForwardConfig>,
 
     pub postgres_local: Option<PostgresConfig>,
@@ -22,11 +14,12 @@ pub struct Config {
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
-pub enum PostgresConfigType {
+pub enum ServerConfigType {
     Kubernetes {
         context: String,
         namespace: String,
         deployment: String,
+        container: Option<String>,
     },
     GCloudProxy {
         instance: String,
@@ -37,7 +30,7 @@ pub enum PostgresConfigType {
 #[derive(Deserialize, Debug)]
 pub struct PostgresConfig {
     #[serde(rename = "type")]
-    pub _type: PostgresConfigType,
+    pub _type: ServerConfigType,
     pub host: Option<String>,
     pub port: Option<u16>,
     pub user: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,19 +3,19 @@ extern crate quick_error;
 #[macro_use]
 extern crate prettytable;
 
-use clap::{App, Arg, SubCommand, value_t};
-use std::{env, fs};
+use clap::{value_t, App, Arg, SubCommand};
 use std::io::Write;
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf, StripPrefixError};
 use std::process::Command;
-use std::os::unix::fs::OpenOptionsExt;
+use std::{env, fs};
 
-use consts::*;
-use config::{EnvironmentType, environment_type, get_config};
-use crate::config::{Config, PostgresConfig, PostgresConfigType, PortForwardConfig};
-use crate::util::ForwardingInfo;
-use prettytable::{Table, format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR};
+use crate::config::{Config, PortForwardConfig, PostgresConfig, PostgresConfigType};
 use crate::runner::run_command;
+use crate::util::ForwardingInfo;
+use config::{environment_type, get_config, EnvironmentType};
+use consts::*;
+use prettytable::{format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR, Table};
 use walkdir::WalkDir;
 
 mod config;
@@ -50,7 +50,7 @@ quick_error! {
 
 /// Recursively walks `path`, collecting any files, optionally filtering by
 /// suffix
-fn collect_files<P: AsRef<Path>>(path: P, match_suffix: Option<&str>)  -> Result<Vec<PathBuf>> {
+fn collect_files<P: AsRef<Path>>(path: P, match_suffix: Option<&str>) -> Result<Vec<PathBuf>> {
     let mut paths = WalkDir::new(path.as_ref())
         .into_iter()
         .map(|e| e.map(|p| p.path().to_path_buf()))
@@ -66,26 +66,35 @@ fn collect_files<P: AsRef<Path>>(path: P, match_suffix: Option<&str>)  -> Result
     Ok(paths)
 }
 
-fn k8s_port_forward(config: Option<&PortForwardConfig>, forwarding: &ForwardingInfo, context: Option<&str>, namespace: Option<&str>) -> Result<()> {
+fn k8s_port_forward(
+    config: Option<&PortForwardConfig>,
+    forwarding: &ForwardingInfo,
+    context: Option<&str>,
+    namespace: Option<&str>,
+) -> Result<()> {
     let (config_context, config_namespace) = match config {
         Some(config) => (Some(config.context.as_str()), config.namespace.as_deref()),
-        None => (None, None)
+        None => (None, None),
     };
 
     // override the values from the config if `context` and `namespace` are explicitly provided:
-    let context_arg = context.or(config_context)
+    let context_arg = context
+        .or(config_context)
         .map_or_else(|| "".to_owned(), |c| format!("--context={}", c));
-    let namespace_arg = namespace.or(config_namespace)
+    let namespace_arg = namespace
+        .or(config_namespace)
         .map_or_else(|| "".to_owned(), |n| format!("--namespace={}", n));
     let pod_name = format!("figcli-temp-port-forward-{}", util::random_alphanum(8));
 
-    let source_contents = format!(include_str!("../template/kubectl-port-forward-remote-host.sh.template"),
-                                  temp_pod_name=pod_name,
-                                  context_arg=context_arg,
-                                  namespace_arg=namespace_arg,
-                                  local_port=forwarding.local_port,
-                                  remote_host=forwarding.remote_host,
-                                  remote_port=forwarding.remote_port);
+    let source_contents = format!(
+        include_str!("../template/kubectl-port-forward-remote-host.sh.template"),
+        temp_pod_name = pod_name,
+        context_arg = context_arg,
+        namespace_arg = namespace_arg,
+        local_port = forwarding.local_port,
+        remote_host = forwarding.remote_host,
+        remote_port = forwarding.remote_port
+    );
 
     // Write the parameterized template out as a shell script to execute:
     let shell_script_name = util::temp_file("sh");
@@ -99,7 +108,10 @@ fn k8s_port_forward(config: Option<&PortForwardConfig>, forwarding: &ForwardingI
 
     let mut port_forward_script = Command::new(shell_script_name.to_str().unwrap());
 
-    println!("Forwarding {}:{} -> {}", forwarding.remote_host, forwarding.remote_port, forwarding.local_port);
+    println!(
+        "Forwarding {}:{} -> {}",
+        forwarding.remote_host, forwarding.remote_port, forwarding.local_port
+    );
 
     runner::run_command(&mut port_forward_script, None, false)
 }
@@ -113,33 +125,41 @@ fn postgres_shell_cmd(config: &PostgresConfig, port: u16) -> Command {
         PostgresConfigType::Direct => config.port(),
     };
 
-    cmd.env("PGPASSWORD", &config.password);
-    cmd.env("PGOPTIONS", format!("--search_path={}", &config.schema()));
-    cmd.args(
-        vec![
-            "-h", &config.host(),
-            "-U", &config.user,
-            "-p", &port.to_string(),
-            &config.database,
-        ]
-    );
+    if let Some(password) = &config.password {
+        cmd.env("PGPASSWORD", password);
+    }
 
-    return cmd
+    cmd.env("PGOPTIONS", format!("--search_path={}", &config.schema()));
+    cmd.args(vec![
+        "-h",
+        &config.host(),
+        "-U",
+        &config.user,
+        "-p",
+        &port.to_string(),
+        &config.database,
+    ]);
+
+    return cmd;
 }
 
 fn postgres_tunnel_cmd(config: &PostgresConfig, port: u16) -> Result<Option<Command>> {
     match &config._type {
-        PostgresConfigType::Kubernetes { context, namespace, deployment } => {
+        PostgresConfigType::Kubernetes {
+            context,
+            namespace,
+            deployment,
+        } => {
             let mut cmd = Command::new("kubectl");
-            cmd.args(
-                vec![
-                    "--context", context,
-                    "--namespace", namespace,
-                    "port-forward",
-                    &format!("deployment/{}", deployment),
-                    &format!("{}:{}", port, &config.port()),
-                ]
-            );
+            cmd.args(vec![
+                "--context",
+                context,
+                "--namespace",
+                namespace,
+                "port-forward",
+                &format!("deployment/{}", deployment),
+                &format!("{}:{}", port, &config.port()),
+            ]);
 
             Ok(Some(cmd))
         }
@@ -149,31 +169,34 @@ fn postgres_tunnel_cmd(config: &PostgresConfig, port: u16) -> Result<Option<Comm
 
             Ok(Some(cmd))
         }
-        PostgresConfigType::Direct => {
-                Ok(None)
-            }
-        }
+        PostgresConfigType::Direct => Ok(None),
+    }
 }
 
-fn postgres_pgbouncer_cmd(config: &PostgresConfig, port: u16, upstream_port: u16) -> Result<Command> {
-    let userlist_file_path_str = util::temp_file("txt");
-    let mut userlist_file = fs::File::create(&userlist_file_path_str)?;
+fn postgres_pgbouncer_cmd(
+    config: &PostgresConfig,
+    port: u16,
+    upstream_port: u16,
+) -> Result<Command> {
     let ini_file_path_str = util::temp_file("ini");
     let mut ini_file = fs::File::create(&ini_file_path_str)?;
 
-    userlist_file.write_all(format!("\"{}\" \"{}\"", &config.user, &config.password).as_bytes())?;
+    let password = config.password.as_ref().ok_or(FigError::ConfigError(
+        "password required when using pgbouncer".to_owned(),
+    ))?;
 
     // TODO change to md5 hash of password
     // TODO remove
     println!("{}", ini_file_path_str.display());
-    println!("\"{}\" \"{}\"", &config.user, &config.password);
+    println!("\"{}\" \"{}\"", &config.user, password);
 
-    let ini_content = format!(include_str!("../template/pgbouncer.toml.template"),
-        database=config.database,
-        upstream_port=upstream_port,
-        user=config.user,
-        password=config.password,
-        listen_port=port
+    let ini_content = format!(
+        include_str!("../template/pgbouncer.toml.template"),
+        database = config.database,
+        upstream_port = upstream_port,
+        user = config.user,
+        password = password,
+        listen_port = port
     );
 
     ini_file.write_all(ini_content.as_bytes())?;
@@ -189,7 +212,8 @@ fn postgres_pgbouncer_cmd(config: &PostgresConfig, port: u16, upstream_port: u16
 
     table.add_row(row![
         "connection string",
-        format!("postgresql://localhost:{}/{}", port, config.database)]);
+        format!("postgresql://localhost:{}/{}", port, config.database)
+    ]);
     table.add_row(row!["host", "localhost"]);
     table.add_row(row!["port", port.to_string()]);
     table.add_row(row!["database", config.database]);
@@ -199,26 +223,32 @@ fn postgres_pgbouncer_cmd(config: &PostgresConfig, port: u16, upstream_port: u16
     Ok(cmd)
 }
 
-fn postgres_cli_cmd(config: &Config, env: Option<&str>, port: Option<u16>, interative_shell: bool) -> Result<()> {
+fn postgres_cli_cmd(
+    config: &Config,
+    env: Option<&str>,
+    port: Option<u16>,
+    interative_shell: bool,
+    use_pgbouncer: bool,
+) -> Result<()> {
     let port = match port {
         Some(port) => port,
         None => {
             let port = util::find_available_port()?;
             println!("Found random open port {}", port);
             port
-        },
+        }
     };
 
     let postgres_config = match environment_type(env)? {
-        EnvironmentType::Local => {
-            config.postgres_local.as_ref().ok_or(FigError::ConfigError("[postgres_local] block is invalid".to_owned()))?
-        },
-        EnvironmentType::Test => {
-            config.postgres_test.as_ref().ok_or(FigError::ConfigError("[postgres_test] block is invalid".to_owned()))?
-        },
-        EnvironmentType::Production => {
-            config.postgres_prod.as_ref().ok_or(FigError::ConfigError("[postgres_prod] block is invalid".to_owned()))?
-        },
+        EnvironmentType::Local => config.postgres_local.as_ref().ok_or(FigError::ConfigError(
+            "[postgres_local] block is invalid".to_owned(),
+        ))?,
+        EnvironmentType::Test => config.postgres_test.as_ref().ok_or(FigError::ConfigError(
+            "[postgres_test] block is invalid".to_owned(),
+        ))?,
+        EnvironmentType::Production => config.postgres_prod.as_ref().ok_or(
+            FigError::ConfigError("[postgres_prod] block is invalid".to_owned()),
+        )?,
     };
 
     if interative_shell {
@@ -228,14 +258,23 @@ fn postgres_cli_cmd(config: &Config, env: Option<&str>, port: Option<u16>, inter
             false,
         )
     } else {
-        let bridge_port = util::find_available_port()?;
-        println!("Using random open port for bridge {}", bridge_port);
-
-        runner::run_command(
-            &mut postgres_pgbouncer_cmd(postgres_config, port, bridge_port)?,
-            postgres_tunnel_cmd(postgres_config, bridge_port)?.as_mut(),
-            false,
-        )
+        if use_pgbouncer {
+            let bridge_port = util::find_available_port()?;
+            println!(
+                "Using pgbouncer with random open port for bridge {}",
+                bridge_port
+            );
+            runner::run_command(
+                &mut postgres_pgbouncer_cmd(postgres_config, port, bridge_port)?,
+                postgres_tunnel_cmd(postgres_config, bridge_port)?.as_mut(),
+                false,
+            )
+        } else {
+            println!("Using default port forwarding");
+            let mut forward_command = postgres_tunnel_cmd(postgres_config, port)?
+                .expect("couldn't build port-forward command");
+            runner::run_command(&mut forward_command, None, false)
+        }
     }
 }
 
@@ -245,11 +284,13 @@ fn doctor_cmd(cmd: &str, args: Vec<&str>) -> Result<()> {
 
     run_command(&mut runnable, None, true)
         .map(|_| println!("[*] {} is installed", cmd))
-        .map_err(|e| { println!("[ ] {} is not installed", cmd); e })
+        .map_err(|e| {
+            println!("[ ] {} is not installed", cmd);
+            e
+        })
 }
 
 fn config_init_cmd<P: AsRef<Path>>(path: P, force: bool, from: Option<(P, P)>) -> Result<()> {
-
     let write_file = if force {
         true
     } else {
@@ -267,10 +308,14 @@ fn config_init_cmd<P: AsRef<Path>>(path: P, force: bool, from: Option<(P, P)>) -
     //   "figure-cli/provenance.toml"
     // - `path` is the destination path of the configuration file to be written
     if let Some((app_config_path, config_file_base_path)) = from {
-        let target_config_file: Option<(PathBuf, PathBuf)> = collect_files(&config_file_base_path, Some("toml"))?
-            .into_iter()
-            .flat_map(|p| p.strip_prefix(config_file_base_path.as_ref()).map(|p_prefix| (p.clone(), p_prefix.to_path_buf())))
-            .find(|(_, prefix_path)| prefix_path == app_config_path.as_ref());
+        let target_config_file: Option<(PathBuf, PathBuf)> =
+            collect_files(&config_file_base_path, Some("toml"))?
+                .into_iter()
+                .flat_map(|p| {
+                    p.strip_prefix(config_file_base_path.as_ref())
+                        .map(|p_prefix| (p.clone(), p_prefix.to_path_buf()))
+                })
+                .find(|(_, prefix_path)| prefix_path == app_config_path.as_ref());
 
         return match target_config_file {
             Some((app_config_full_path, _)) => {
@@ -280,8 +325,11 @@ fn config_init_cmd<P: AsRef<Path>>(path: P, force: bool, from: Option<(P, P)>) -
                 println!("Writing config file to {}", path.as_ref().display());
                 result
             }
-            None => Err(FigError::ConfigError(format!("Can't copy configuration {}", app_config_path.as_ref().display())))
-        }
+            None => Err(FigError::ConfigError(format!(
+                "Can't copy configuration {}",
+                app_config_path.as_ref().display()
+            ))),
+        };
     }
 
     let mut file = fs::OpenOptions::new()
@@ -305,7 +353,11 @@ fn config_show_path<P: AsRef<Path>>(path: P, check: bool) -> Result<()> {
     let path = path.as_ref();
     if check {
         let exists = path.exists();
-        println!("Checking - {} {}", path.display(), if exists { GREEN_CHECK_ICON } else { RED_X_ICON });
+        println!(
+            "Checking - {} {}",
+            path.display(),
+            if exists { GREEN_CHECK_ICON } else { RED_X_ICON }
+        );
     } else {
         println!("{}", path.display());
     }
@@ -322,7 +374,7 @@ fn config_edit_path<P: AsRef<Path>>(path: P) -> Result<()> {
     Ok(())
 }
 
-fn config_list_files<P: AsRef<Path>>(path: P)  -> Result<()> {
+fn config_list_files<P: AsRef<Path>>(path: P) -> Result<()> {
     for p in collect_files(&path, Some("toml"))? {
         println!("{}", p.strip_prefix(&path)?.display());
     }
@@ -330,7 +382,6 @@ fn config_list_files<P: AsRef<Path>>(path: P)  -> Result<()> {
 }
 
 fn main() -> Result<()> {
-
     let (default_config_path, base_config_path) = {
         let mut default_config_path = dirs::config_dir().unwrap();
         default_config_path.push(FIG_CONFIG_DIR);
@@ -354,11 +405,16 @@ fn main() -> Result<()> {
         .value_name("PORT")
         .takes_value(true)
         .help("Optional static port. If omitted, a random open port is chosen.");
-    let interactive_shell_args = Arg::with_name("shell")
+    let interactive_shell_arg = Arg::with_name("shell")
         .short("s")
         .long("shell")
         .takes_value(false)
         .help("Optionally starts a psql shell.");
+    let pgbouncer_arg = Arg::with_name("pgbouncer")
+        .long("pgbouncer")
+        .value_name("PGBOUNCER")
+        .takes_value(false)
+        .help("Enable pgbouncer usage for tunnelling. If not provided with kubectl or some other method. Not compatible with --shell");
     let env_arg = Arg::with_name("environment")
         .required(true)
         .index(1)
@@ -457,7 +513,8 @@ fn main() -> Result<()> {
         .subcommand(SubCommand::with_name(POSTGRES_CLI)
             .arg(&env_arg)
             .arg(&static_port_arg)
-            .arg(&interactive_shell_args)
+            .arg(&interactive_shell_arg)
+            .arg(&pgbouncer_arg)
             .about("Proxies a remote postgres connection")
         );
 
@@ -478,47 +535,48 @@ fn main() -> Result<()> {
             ];
 
             if commands.iter().any(|res| res.is_err()) {
-                return Err(FigError::DoctorError("Please make sure all of the above checks are successful!".to_owned()))
+                return Err(FigError::DoctorError(
+                    "Please make sure all of the above checks are successful!".to_owned(),
+                ));
             }
-        },
-        (CONFIG, Some(values)) => {
-            match values.subcommand() {
-                (CHECK, _) => {
-                    config_show_path(config_path, true)?
-                },
-                (EDIT, _) => {
-                    config_edit_path(config_path)?
-                },
-                (INIT, Some(init)) => {
-                    config_init_cmd(config_path, init.is_present("force"), init.value_of("from").map(|p| (PathBuf::from(p), base_config_path)))?
-                },
-                (LIST, Some(list)) => {
-                    config_list_files(if list.is_present("all") {
-                        &base_config_path
-                    } else {
-                        &default_config_path
-                    })?
-                },
-                (PATH, _) => {
-                    config_show_path(config_path, false)?
-                },
-                (SHOW, _) => {
-                    config_show_contents(config_path)?
-                },
-                _ => {
-                    app_help.print_help().unwrap();
-                }
+        }
+        (CONFIG, Some(values)) => match values.subcommand() {
+            (CHECK, _) => config_show_path(config_path, true)?,
+            (EDIT, _) => config_edit_path(config_path)?,
+            (INIT, Some(init)) => config_init_cmd(
+                config_path,
+                init.is_present("force"),
+                init.value_of("from")
+                    .map(|p| (PathBuf::from(p), base_config_path)),
+            )?,
+            (LIST, Some(list)) => config_list_files(if list.is_present("all") {
+                &base_config_path
+            } else {
+                &default_config_path
+            })?,
+            (PATH, _) => config_show_path(config_path, false)?,
+            (SHOW, _) => config_show_contents(config_path)?,
+            _ => {
+                app_help.print_help().unwrap();
             }
         },
         (PORT_FORWARD, Some(values)) => {
             let config = get_config(config_path)?;
-            let forwarding = util::parse_forwarding_string(&(values.value_of("forward")
-                                                             .ok_or(FigError::ParseError("Could not parse remote string".to_owned()))?))?;
+            let forwarding = util::parse_forwarding_string(
+                &(values.value_of("forward").ok_or(FigError::ParseError(
+                    "Could not parse remote string".to_owned(),
+                ))?),
+            )?;
             let context = values.value_of("context");
             let namespace = values.value_of("namespace");
 
-            k8s_port_forward(config.port_forward.as_ref(), &forwarding, context, namespace)?
-        },
+            k8s_port_forward(
+                config.port_forward.as_ref(),
+                &forwarding,
+                context,
+                namespace,
+            )?
+        }
         (POSTGRES_CLI, Some(values)) => {
             // TODO on this error make sure printed messages shows you how to create a config file
             let config = get_config(config_path)?;
@@ -526,15 +584,24 @@ fn main() -> Result<()> {
                 Ok(port) => Ok(Some(port)),
                 Err(e) => match e.kind {
                     clap::ErrorKind::ArgumentNotFound => Ok(None),
-                    clap::ErrorKind::InvalidValue => Err(FigError::ParseError("Could not parse port to u16.".to_owned())),
+                    clap::ErrorKind::InvalidValue => Err(FigError::ParseError(
+                        "Could not parse port to u16.".to_owned(),
+                    )),
                     // TDOO figure out which error conditions we need to add
-                    _ => unreachable!()
+                    _ => unreachable!(),
                 },
             }?;
             let interactive_shell = values.is_present("shell");
+            let use_pgbouncer = values.is_present("pgbouncer");
 
-            postgres_cli_cmd(&config, values.value_of("environment"), port, interactive_shell)?
-        },
+            postgres_cli_cmd(
+                &config,
+                values.value_of("environment"),
+                port,
+                interactive_shell,
+                use_pgbouncer,
+            )?
+        }
         _ => {
             // print help by default:
             app_help.print_help().unwrap();

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -11,15 +11,16 @@ pub fn run_command(
 ) -> crate::Result<()> {
     let parent = if let Some(cmd) = parent_command {
         let proc = if suppress_std {
-            cmd.stderr(Stdio::null())
-                .stdout(Stdio::null())
+            cmd.stderr(Stdio::null()).stdout(Stdio::null())
         } else {
             cmd
         };
         let proc = proc.spawn()?;
 
         // TODO instead of static delay read stdout for matching regex?
-        println!("Sleeping 5 seconds to give parent process time to startup. This needs to be fixed!");
+        println!(
+            "Sleeping 5 seconds to give parent process time to startup. This needs to be fixed!"
+        );
         thread::sleep(Duration::from_millis(5_000));
 
         Some(proc)
@@ -28,10 +29,9 @@ pub fn run_command(
     };
 
     let command_proc = if suppress_std {
-        command.stderr(Stdio::null())
-            .stdout(Stdio::null())
+        command.stderr(Stdio::null()).stdout(Stdio::null())
     } else {
-       command
+        command
     };
     let mut command_proc = command_proc.spawn()?;
 
@@ -52,10 +52,12 @@ pub fn run_command(
                 return if status.success() {
                     Ok(())
                 } else {
-                    Err(FigError::ExecError("child exited unsuccessfully".to_owned()))
-                }
+                    Err(FigError::ExecError(
+                        "child exited unsuccessfully".to_owned(),
+                    ))
+                };
             }
-            _ => thread::sleep(Duration::from_millis(200))
+            _ => thread::sleep(Duration::from_millis(200)),
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,19 +1,19 @@
-use std::net::UdpSocket;
+use std::env::temp_dir;
 use std::io;
 use std::iter;
+use std::net::UdpSocket;
 use std::path::{Path, PathBuf};
-use std::env::temp_dir;
 
-use rand::{Rng, thread_rng};
-use rand::distributions::Alphanumeric;
 use getch::Getch;
+use rand::distributions::Alphanumeric;
+use rand::{thread_rng, Rng};
 use uuid::Uuid;
 
 #[derive(Clone, Debug)]
 pub struct ForwardingInfo {
     pub local_port: u16,
     pub remote_host: String,
-    pub remote_port: u16
+    pub remote_port: u16,
 }
 
 pub fn find_available_port() -> Result<u16, std::io::Error> {
@@ -34,29 +34,35 @@ pub fn temp_file(extension: &str) -> PathBuf {
 pub fn parse_forwarding_string(host: &str) -> Result<ForwardingInfo, io::Error> {
     let parts = host.split(":").collect::<Vec<&str>>();
     if parts.len() == 3 {
-        let local_port = parts[0].parse::<u16>()
+        let local_port = parts[0]
+            .parse::<u16>()
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
         let remote_host = parts[1];
-        let remote_port = parts[2].parse::<u16>()
+        let remote_port = parts[2]
+            .parse::<u16>()
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
         Ok(ForwardingInfo {
             local_port,
             remote_host: remote_host.to_owned(),
-            remote_port
+            remote_port,
         })
     } else if parts.len() == 2 {
         let remote_host = parts[0];
-        let remote_port = parts[1].parse::<u16>()
+        let remote_port = parts[1]
+            .parse::<u16>()
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
         Ok(ForwardingInfo {
             local_port: find_available_port()?, // pick a random port
             remote_host: remote_host.to_owned(),
-            remote_port
+            remote_port,
         })
     } else {
-        Err(io::Error::new(io::ErrorKind::InvalidInput, "expected \
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "expected \
                            \"<local-port>:<remote-host>:<remote-port>\" \
-                           or \"<remote-host>:<remote-port>\""))
+                           or \"<remote-host>:<remote-port>\"",
+        ))
     }
 }
 
@@ -73,7 +79,10 @@ pub fn random_alphanum(len: usize) -> String {
 
 pub fn prompt_on_write<P: AsRef<Path>>(path: P) -> bool {
     if path.as_ref().exists() {
-        println!("\n{} already exists.\n\nOverwrite [y/n]?", path.as_ref().display());
+        println!(
+            "\n{} already exists.\n\nOverwrite [y/n]?",
+            path.as_ref().display()
+        );
         let ch = Getch::new().getch().unwrap_or(0) as char;
         ch == 'y' || ch == 'Y'
     } else {


### PR DESCRIPTION
- Toggle the use of pgbouncer with `--pgbouncer` flag. If omitted, the default port forwarding mechanism will be used, e.g. kubectl port-forward

- Make providing a PG password optional. Sometimes passwords are not required and this change reflects that fact.

- Rename `PostgresConfigType` to the more generic `ServerConfigType`

- Add optional `container` value to Kubernetes config