### PR TITLE
Complete pods after they've been running for 8 hours.

### DIFF
--- a/template/kubectl-port-forward-remote-host.sh.template
+++ b/template/kubectl-port-forward-remote-host.sh.template
@@ -11,6 +11,6 @@ function cleanup {{
 
 trap cleanup EXIT
 
-kubectl run {context_arg} {namespace_arg} --restart=Never --image=alpine/socat {temp_pod_name} -- -d -d tcp-listen:{remote_port},fork,reuseaddr tcp-connect:{remote_host}:{remote_port}
+kubectl run {context_arg} {namespace_arg} --restart=Never --overrides='{"spec": {"activeDeadlineSeconds": 28800}}' --image=alpine/socat {temp_pod_name} -- -d -d tcp-listen:{remote_port},fork,reuseaddr tcp-connect:{remote_host}:{remote_port}
 kubectl wait {context_arg} {namespace_arg} --for=condition=Ready pod/{temp_pod_name}
 kubectl port-forward {context_arg} {namespace_arg} pod/{temp_pod_name} {local_port}:{remote_port}

--- a/template/kubectl-port-forward-remote-host.sh.template
+++ b/template/kubectl-port-forward-remote-host.sh.template
@@ -11,6 +11,6 @@ function cleanup {{
 
 trap cleanup EXIT
 
-kubectl run {context_arg} {namespace_arg} --restart=Never --overrides='{"spec": {"activeDeadlineSeconds": 28800}}' --image=alpine/socat {temp_pod_name} -- -d -d tcp-listen:{remote_port},fork,reuseaddr tcp-connect:{remote_host}:{remote_port}
+kubectl run {context_arg} {namespace_arg} --restart=Never --overrides='{{"spec": {{"activeDeadlineSeconds": 28800}}}}' --image=alpine/socat {temp_pod_name} -- -d -d tcp-listen:{remote_port},fork,reuseaddr tcp-connect:{remote_host}:{remote_port}
 kubectl wait {context_arg} {namespace_arg} --for=condition=Ready pod/{temp_pod_name}
 kubectl port-forward {context_arg} {namespace_arg} pod/{temp_pod_name} {local_port}:{remote_port}


### PR DESCRIPTION
`figcli` pods get orphaned and stay running forever in some scenarios. The most likely scenario is when
a user closes their VPN connection before terminating the running process. This addition sets an 8 hour
timeout where the pod will be cleaned up on its own. If you work more than 8 hours straight, you'll have
to restart the tunnel.

```yaml
21:46 $ kubectl run --restart=Never --overrides='{"spec": {"activeDeadlineSeconds": 28800}}' --dry-run=client -o yaml --image=alpine/socat testing -- -d -d tcp-listen:{remote_port},fork,reuseaddr tcp-connect:{remote_host}:{remote_port}

apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: null
  labels:
    run: testing
  name: testing
spec:
  activeDeadlineSeconds: 28800
  containers:
  - args:
    - -d
    - -d
    - tcp-listen:{remote_port},fork,reuseaddr
    - tcp-connect:{remote_host}:{remote_port}
    image: alpine/socat
    name: testing
    resources: {}
  dnsPolicy: ClusterFirst
  restartPolicy: Never
status: {}
```
