### PR TITLE
Add linkerd annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bitflags"
@@ -104,12 +104,11 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
- "lazy_static",
 ]
 
 [[package]]
@@ -211,13 +210,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -243,9 +242,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "memchr"
@@ -275,11 +274,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.38"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -290,9 +289,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -320,11 +319,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -335,9 +334,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
@@ -359,8 +358,8 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.6",
- "redox_syscall 0.2.13",
+ "getrandom 0.2.8",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
@@ -384,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "same-file"
@@ -399,18 +398,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -425,13 +424,13 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.92"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -465,18 +464,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -493,24 +492,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
+name = "unicode-ident"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.3"
+name = "unicode-width"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "uuid"
-version = "1.0.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
+checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -538,9 +537,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "figcli"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Stephen Cirner <scirner@figure.com>", "Mike Woods <mwoods@figure.com>"]
 edition = "2018"
 description = "A command line tool that provides utility functions for developing at Figure."

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
+use crate::FigError::EnvError;
 use serde::Deserialize;
 use std::fs;
 use std::path::Path;
-use crate::FigError::EnvError;
 
 #[derive(Deserialize, Debug)]
 pub struct Config {
@@ -13,7 +13,6 @@ pub struct Config {
 
     // exec_test: Option<ExecConfig>,
     // exec_prod: Option<ExecConfig>,
-
     pub port_forward: Option<PortForwardConfig>,
 
     pub postgres_local: Option<PostgresConfig>,
@@ -24,8 +23,14 @@ pub struct Config {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum PostgresConfigType {
-    Kubernetes { context: String, namespace: String, deployment: String },
-    GCloudProxy { instance: String },
+    Kubernetes {
+        context: String,
+        namespace: String,
+        deployment: String,
+    },
+    GCloudProxy {
+        instance: String,
+    },
     Direct,
 }
 
@@ -58,7 +63,7 @@ impl PostgresConfig {
 #[derive(Deserialize, Debug)]
 pub struct PortForwardConfig {
     pub context: String,
-    pub namespace: Option<String>
+    pub namespace: Option<String>,
 }
 
 // #[derive(Deserialize, Debug)]
@@ -91,13 +96,12 @@ pub fn environment_type(env: Option<&str>) -> crate::Result<EnvironmentType> {
         Some(crate::LOCAL) => Ok(EnvironmentType::Local),
         Some(crate::TEST) => Ok(EnvironmentType::Test),
         Some(crate::PRODUCTION) => Ok(EnvironmentType::Production),
-        _ => Err(EnvError("environment not set".to_owned()))
+        _ => Err(EnvError("environment not set".to_owned())),
     }
 }
 
 pub fn get_config<P: AsRef<Path>>(path: P) -> crate::Result<Config> {
     let toml_string = fs::read_to_string(path)?;
 
-    toml::from_str(&toml_string)
-        .map_err(From::from)
+    toml::from_str(&toml_string).map_err(From::from)
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -11,15 +11,16 @@ pub fn run_command(
 ) -> crate::Result<()> {
     let parent = if let Some(cmd) = parent_command {
         let proc = if suppress_std {
-            cmd.stderr(Stdio::null())
-                .stdout(Stdio::null())
+            cmd.stderr(Stdio::null()).stdout(Stdio::null())
         } else {
             cmd
         };
         let proc = proc.spawn()?;
 
         // TODO instead of static delay read stdout for matching regex?
-        println!("Sleeping 5 seconds to give parent process time to startup. This needs to be fixed!");
+        println!(
+            "Sleeping 5 seconds to give parent process time to startup. This needs to be fixed!"
+        );
         thread::sleep(Duration::from_millis(5_000));
 
         Some(proc)
@@ -28,10 +29,9 @@ pub fn run_command(
     };
 
     let command_proc = if suppress_std {
-        command.stderr(Stdio::null())
-            .stdout(Stdio::null())
+        command.stderr(Stdio::null()).stdout(Stdio::null())
     } else {
-       command
+        command
     };
     let mut command_proc = command_proc.spawn()?;
 
@@ -52,10 +52,12 @@ pub fn run_command(
                 return if status.success() {
                     Ok(())
                 } else {
-                    Err(FigError::ExecError("child exited unsuccessfully".to_owned()))
-                }
+                    Err(FigError::ExecError(
+                        "child exited unsuccessfully".to_owned(),
+                    ))
+                };
             }
-            _ => thread::sleep(Duration::from_millis(200))
+            _ => thread::sleep(Duration::from_millis(200)),
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,19 +1,19 @@
-use std::net::UdpSocket;
+use std::env::temp_dir;
 use std::io;
 use std::iter;
+use std::net::UdpSocket;
 use std::path::{Path, PathBuf};
-use std::env::temp_dir;
 
-use rand::{Rng, thread_rng};
-use rand::distributions::Alphanumeric;
 use getch::Getch;
+use rand::distributions::Alphanumeric;
+use rand::{thread_rng, Rng};
 use uuid::Uuid;
 
 #[derive(Clone, Debug)]
 pub struct ForwardingInfo {
     pub local_port: u16,
     pub remote_host: String,
-    pub remote_port: u16
+    pub remote_port: u16,
 }
 
 pub fn find_available_port() -> Result<u16, std::io::Error> {
@@ -34,29 +34,35 @@ pub fn temp_file(extension: &str) -> PathBuf {
 pub fn parse_forwarding_string(host: &str) -> Result<ForwardingInfo, io::Error> {
     let parts = host.split(':').collect::<Vec<&str>>();
     if parts.len() == 3 {
-        let local_port = parts[0].parse::<u16>()
+        let local_port = parts[0]
+            .parse::<u16>()
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
         let remote_host = parts[1];
-        let remote_port = parts[2].parse::<u16>()
+        let remote_port = parts[2]
+            .parse::<u16>()
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
         Ok(ForwardingInfo {
             local_port,
             remote_host: remote_host.to_owned(),
-            remote_port
+            remote_port,
         })
     } else if parts.len() == 2 {
         let remote_host = parts[0];
-        let remote_port = parts[1].parse::<u16>()
+        let remote_port = parts[1]
+            .parse::<u16>()
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
         Ok(ForwardingInfo {
             local_port: find_available_port()?, // pick a random port
             remote_host: remote_host.to_owned(),
-            remote_port
+            remote_port,
         })
     } else {
-        Err(io::Error::new(io::ErrorKind::InvalidInput, "expected \
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "expected \
                            \"<local-port>:<remote-host>:<remote-port>\" \
-                           or \"<remote-host>:<remote-port>\""))
+                           or \"<remote-host>:<remote-port>\"",
+        ))
     }
 }
 
@@ -73,7 +79,10 @@ pub fn random_alphanum(len: usize) -> String {
 
 pub fn prompt_on_write<P: AsRef<Path>>(path: P) -> bool {
     if path.as_ref().exists() {
-        println!("\n{} already exists.\n\nOverwrite [y/n]?", path.as_ref().display());
+        println!(
+            "\n{} already exists.\n\nOverwrite [y/n]?",
+            path.as_ref().display()
+        );
         let ch = Getch::new().getch().unwrap_or(0) as char;
         ch == 'y' || ch == 'Y'
     } else {

--- a/template/kubectl-port-forward-remote-host.sh.template
+++ b/template/kubectl-port-forward-remote-host.sh.template
@@ -11,6 +11,6 @@ function cleanup {{
 
 trap cleanup EXIT
 
-kubectl run {context_arg} {namespace_arg} --restart=Never --overrides='{{"spec": {{"activeDeadlineSeconds": 28800}}}}' --image=alpine/socat {temp_pod_name} -- -d -d tcp-listen:{remote_port},fork,reuseaddr tcp-connect:{remote_host}:{remote_port}
+kubectl run {context_arg} {namespace_arg} --restart=Never --overrides='{{"metadata": {{"annotations": {{"linkerd.io/inject": "disabled"}}}}, "spec": {{"activeDeadlineSeconds": 28800}}}}' --image=alpine/socat {temp_pod_name} -- -d -d tcp-listen:{remote_port},fork,reuseaddr tcp-connect:{remote_host}:{remote_port}
 kubectl wait {context_arg} {namespace_arg} --for=condition=Ready pod/{temp_pod_name}
 kubectl port-forward {context_arg} {namespace_arg} pod/{temp_pod_name} {local_port}:{remote_port}


### PR DESCRIPTION
Adds the linkerd disabled header on the socat pod. There's no reason for it to be present and I'm unsure how it works when combined with socat.

Ran `cargo fmt` and `cargo update` as well.
