### PR TITLE
Make config file fully optional for port-forward command.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -721,7 +721,7 @@ include both the caller and what system they are calling, i.e.
             config_path.push(args.value_of("config").unwrap());
             config_path.set_extension("toml");
 
-            let config = get_config(config_path)?;
+            let port_forward_config = get_config(config_path).ok().and_then(|c| c.port_forward);
             let forward_value = values
                 .value_of("forward")
                 .ok_or_else(|| FigError::ParseError("Could not parse remote string".to_owned()))?;
@@ -730,7 +730,7 @@ include both the caller and what system they are calling, i.e.
             let namespace = values.value_of("namespace");
 
             k8s_port_forward(
-                config.port_forward.as_ref(),
+                port_forward_config.as_ref(),
                 &forwarding,
                 context,
                 namespace,


### PR DESCRIPTION
It seems like everyone asks why they get an error with the port-forward command. The root cause of this is that this repo was originally built to make heavy use of a config file that is dependent on your current working directory. This file was leveraged for the port-forward command to allow for base k8s settings that are overridable with flags. This change makes the config file fully optional since it's often used without needing a config file at all.
