### PR TITLE
Add flag for IAM login to Cloud SQL Proxy command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "figcli"
-version = "0.8.0"
+version = "0.11.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "figcli"
-version = "0.8.0"
+version = "0.11.0"
 authors = ["Stephen Cirner <scirner@figure.com>", "Mike Woods <mwoods@figure.com>"]
 edition = "2018"
 description = "A command line tool that provides utility functions for developing at Figure."

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,7 +238,7 @@ fn postgres_tunnel_cmd(config: &PostgresConfig, port: u16) -> Result<Option<Comm
         }
         ServerConfigType::GCloudProxy { instance } => {
             let mut cmd = Command::new("cloud_sql_proxy");
-            cmd.args(vec!["-instances", &format!("{}=tcp:{}", instance, port)]);
+            cmd.args(vec!["-instances", &format!("{}=tcp:{}", instance, port), "-enable_iam_login"]);
 
             Ok(Some(cmd))
         }


### PR DESCRIPTION
Adding the `-enable_iam_login` flag to the Cloud SQL Proxy command. Please do let me know if it's not OK for the flag to always be supplied here.